### PR TITLE
pass all user information to identify analytics

### DIFF
--- a/src/app/shared/keycloak.service.ts
+++ b/src/app/shared/keycloak.service.ts
@@ -32,7 +32,7 @@ export class KeycloakService {
             this.loginSubject.next(keycloakAuth.token);
             this.auth.logoutUrl = `${keycloakAuth.authServerUrl}/realms/${config.realm}/protocol/openid-connect/logout?redirect_uri=${document.baseURI}`;
             if (window['analytics']) {
-              window['analytics'].identify(this.auth.authz.tokenParsed);
+              window['analytics'].identify(this.auth.authz.tokenParsed.email, this.auth.authz.tokenParsed);
             }
             resolve(this);
           });

--- a/src/app/shared/keycloak.service.ts
+++ b/src/app/shared/keycloak.service.ts
@@ -31,6 +31,9 @@ export class KeycloakService {
             this.auth.authz = keycloakAuth;
             this.loginSubject.next(keycloakAuth.token);
             this.auth.logoutUrl = `${keycloakAuth.authServerUrl}/realms/${config.realm}/protocol/openid-connect/logout?redirect_uri=${document.baseURI}`;
+            if (window['analytics']) {
+              window['analytics'].identify(this.auth.authz.tokenParsed);
+            }
             resolve(this);
           });
       } else {


### PR DESCRIPTION
@quintesse passes all the info from keycloak to identify example info:

```json
{
  "jti": "1379054b-b8b4-442a-adb1-d69e3a16984d",
  "exp": 1516381557,
  "nbf": 0,
  "iat": 1516381497,
  "iss": "http://localhost:8280/auth/realms/master",
  "aud": "openshiftio-public",
  "sub": "18b9c78f-eb0c-4831-aeac-2ca0e467e5fa",
  "typ": "Bearer",
  "azp": "openshiftio-public",
  "nonce": "4ba36b28-c1fd-4832-8283-4245e85642e7",
  "auth_time": 1516381494,
  "session_state": "3284773f-75c2-4eee-8637-ad7d70ff01d9",
  "acr": "1",
  "allowed-origins": [
    "*"
  ],
  "realm_access": {
    "roles": [
      "uma_authorization"
    ]
  },
  "resource_access": {
    "account": {
      "roles": [
        "manage-account",
        "manage-account-links",
        "view-profile"
      ]
    }
  },
  "name": "Erik de Wit",
  "preferred_username": "edewit",
  "given_name": "Erik",
  "family_name": "de Wit",
  "email": "erik"
}
```