### PR TITLE
task: remove tech preview ribbon from Node.js logo

### DIFF
--- a/src/app/wizard/pages/intro/intro.component.html
+++ b/src/app/wizard/pages/intro/intro.component.html
@@ -67,7 +67,6 @@
 
       <div class="col-sm-4 runtime">
         <div class="fa icon node"></div>
-        <div class="ribbon ribbon-top-right"><span>technology preview</span></div>
         <p>
             Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
             Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient.

--- a/src/app/wizard/pages/runtime/runtime.page.ts
+++ b/src/app/wizard/pages/runtime/runtime.page.ts
@@ -9,7 +9,7 @@ export class RuntimePage {
   @Input() gui: Gui;
   config: ProjectSelectConfig = {
     classes: ['Node','Spring','WildFly','Vert', 'Fuse'],
-    techPreview: ['Node','Fuse'],
+    techPreview: ['Fuse'],
     renderType: 'title'
   }
 }


### PR DESCRIPTION
This is for the eventual removal of the tech preview ribbon for the node.js logo

I think these were the only locations for them

NOT TO BE MERGED YET