### PR TITLE
update(nodejs): Update to Node.js 8.9.4

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -9,7 +9,7 @@ CMD ["/usr/bin/bash"]
 ENV LANG=en_US.utf8
 ENV USER_NAME=forge
 #ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.9.2
+ENV NODE_VERSION 8.9.4
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -22,6 +22,8 @@ RUN set -ex \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --keyserver pgp.mit.edu --recv-keys "$key" || \


### PR DESCRIPTION
@edewit this should enable the build to use Node.js 8.9.4. Give it a try before pushing to master. 

Make sure to run `CICO_LOCAL=true bash cico_build_deploy.sh` to check if the build works