### PR TITLE
fix: WebSocket URL building is now the same as in fabric8-ui

### DIFF
--- a/src/app/wizard/services/app-launcher-project-progress.service.ts
+++ b/src/app/wizard/services/app-launcher-project-progress.service.ts
@@ -17,8 +17,12 @@ export class AppLauncherProjectProgressService implements ProjectProgressService
   constructor(private helperService: HelperService) {
     this.END_POINT = this.helperService.getBackendUrl();
     this.END_POINT = this.END_POINT.split('/api')[0];
-
-    if (this.END_POINT && (this.END_POINT.startsWith("/") || this.END_POINT.startsWith(":"))) {
+    if (this.END_POINT.indexOf('https') !== -1) {
+      this.END_POINT = this.END_POINT.replace('https', 'wss');
+    } else if (this.END_POINT.indexOf('http') !== -1) {
+      this.END_POINT = this.END_POINT.replace('http', 'wss');
+    } else if (this.END_POINT.startsWith("/") || this.END_POINT.startsWith(":")) {
+      // /launch/api
       this.END_POINT = (this.END_POINT.startsWith(":") ? location.hostname : location.host) + this.END_POINT;
       this.END_POINT = (location.protocol === "https:" ? "wss://" : "ws://") + this.END_POINT;
     }


### PR DESCRIPTION
Copied from https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/space/app-launcher/services/app-launcher-project-progress.service.ts#L21-L24