### PR TITLE
fix: use catalog as fallback mission description

### DIFF
--- a/src/app/shared/forge.enhance.service.ts
+++ b/src/app/shared/forge.enhance.service.ts
@@ -61,7 +61,10 @@ export class EnhancedForgeService extends ForgeService {
           if (input.valueChoices) {
             input.valueChoices.forEach(choice => {
               let key = input.name + (choice.key ? choice.key : choice.id);
-              choice.description = this.asciidoc.generateHtml(key);
+              let asciidocDescription = this.asciidoc.generateHtml(key);
+              if (asciidocDescription) {
+                choice.description = asciidocDescription;
+              }
             });
           }
         });


### PR DESCRIPTION
fixes: #305 

@cmoulliard fix in the old UI to make show mission description from the catalog 