### PR TITLE
Build on RHEL

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,19 @@
+FROM prod.registry.devshift.net/osio-prod/base/openshift-nginx:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV LANG=en_US.utf8
+ENTRYPOINT /usr/bin/entrypoint.sh
+
+USER root
+ADD nginx.conf /etc/nginx/nginx.conf
+
+COPY scripts/entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+
+RUN rm /usr/share/nginx/html/*
+
+COPY dist /usr/share/nginx/html/launch
+RUN chmod a+w /usr/share/nginx/html/launch
+
+USER 997


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

- The build scripts will be executed twice on the same machine, once for
  CentOS and one for RHEL
- `docker login` is required to run `docker build`
- The image target is different if TARGET=rhel
- There is a separate Dockerfile for the RHEL build