### PR TITLE
Removed tehc preview ribbon from Fuse runtime.

### DIFF
--- a/src/app/wizard/pages/intro/intro.component.html
+++ b/src/app/wizard/pages/intro/intro.component.html
@@ -6,7 +6,7 @@
       Continuous application delivery,
     </h1>
     <h1>
-      built and deployed on OpenShift. 
+      built and deployed on OpenShift.
     </h1>
 
     <div class="launch-box">
@@ -59,7 +59,6 @@
     <div class="preview row">
       <div class="col-sm-offset-2 col-sm-4 runtime">
         <div class="fa icon fuse"></div>
-        <div class="ribbon ribbon-top-right"><span>technology preview</span></div>
         <p>
             Red Hat® Fuse is a lightweight, flexible integration platform that uses Apache Camel at his core.
         </p>


### PR DESCRIPTION
I seems to remember there was another place to be modified like we did in https://github.com/fabric8-launcher/launcher-frontend/pull/231/files but I can not find it any more.