### PR TITLE
feat: show error reporting dialog when JS errors are captured

### DIFF
--- a/src/app/shared/error.component.ts
+++ b/src/app/shared/error.component.ts
@@ -6,6 +6,7 @@ class RavenErrorHandler extends ErrorHandler {
   handleError(err: any): void {
     if (err) {
       Raven.captureException(err.originalError || err);
+      Raven.showReportDialog();
     }
     super.handleError(err);
   }


### PR DESCRIPTION
Dialog example: https://errortracking.prod-preview.openshift.io/openshift_io/fabric8-launcher-frontend/settings/user-feedback/

![screenshot from 2018-06-08 11-30-36](https://user-images.githubusercontent.com/54133/41163561-64273382-6b0f-11e8-83ea-25d077d1a5ce.png)


Related to #325 
