### PR TITLE
fix: changed to smaller valid JWT token

### DIFF
--- a/src/app/shared/keycloak.service.ts
+++ b/src/app/shared/keycloak.service.ts
@@ -132,8 +132,7 @@ export class KeycloakService {
             reject('Failed to refresh token');
           });
       } else {
-        // tslint:disable-next-line
-        resolve('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o');
+        resolve('eyJhbGciOiJIUzI1NiJ9.e30.ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo');
       }
     });
   }


### PR DESCRIPTION
fixes: https://github.com/fabric8-launcher/launcher-backend/issues/496

This was accidentally introduced by this commit: https://github.com/fabric8-launcher/launcher-frontend/commit/b964ad37ea0403c3043077a9c82e8daafc116aa2#diff-0a354681939e046826a694eeefcc3921L120

Removed all the info from the dummy token making it less long.