### PR TITLE
fix(git): Remove fixed X-Git-Provider header value

### DIFF
--- a/src/app/wizard/services/http.service.ts
+++ b/src/app/wizard/services/http.service.ts
@@ -50,7 +50,6 @@ export class HttpService {
   protected options(cluster?: Cluster, retry: number = 0): Observable<object> {
     let headers = new HttpHeaders()
       .append('X-App', this.helperService.getOrigin())
-      .append('X-Git-Provider', 'GitHub')
       .append('X-Execution-Step-Index', String(retry));
     if (cluster) {
       headers = headers.append('X-OpenShift-Cluster', cluster.id);


### PR DESCRIPTION
The backend may be configured to use Gitea or any other Git provider, therefore passing a fixed value as 'GitHub' will not work.
This header must be set according to the chosen Git Provider as returned by the /api/services/git/providers endpoint from the launcher-backend service.