### PR TITLE
Feat loading script

### DIFF
--- a/packages/launcher-app/public/index.html
+++ b/packages/launcher-app/public/index.html
@@ -48,10 +48,21 @@
             console.info("GLOBAL_CONFIG is undefined");
         }
     </script>
+    <style>
+        #loading {
+            margin: 300px auto;
+            font-family: monospace;
+            text-align: center;
+            padding: 20px;
+            border: 1px dashed #777777;
+            width: 300px;
+            font-size: 1.3em;
+        }
+    </style>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>
-<div id="root"></div>
+<div id="root"><div id="loading">Loading the Launcher...</div></div>
 <!--
   This HTML file is a template.
   If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
This is only when script is not loaded yet. At the same time it shows that the launcher app server is on (in case of script errors)

![image](https://user-images.githubusercontent.com/2223984/54915322-2370e280-4ef7-11e9-92fa-0db6a09b791a.png)
