### PR TITLE
chore: add reverse proxy to Github

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -73,6 +73,10 @@ http {
             proxy_pass http://creator-backend/;
         }
 
+        location /launch/github/access_token {
+            proxy_pass https://github.com/login/oauth/access_token;
+        }
+
         # Reference: https://serversforhackers.com/c/nginx-caching
         # cache.appcache, your document html and data
         location ~* \.(?:manifest|appcache|html?|xml|json)$ {


### PR DESCRIPTION
Adds a reverse proxy to https://github.com/login/oauth/access_token as an attempt to avoid CORS