### PR TITLE
fix: we don't need git oauth on import

### DIFF
--- a/packages/launcher-client/src/client/impl/default.launcher.client.ts
+++ b/packages/launcher-client/src/client/impl/default.launcher.client.ts
@@ -101,8 +101,9 @@ export default class DefaultLauncherClient implements LauncherClient {
       endpoint = Locations.joinPath(this.config.launcherURL, '/launcher');
       p = ExampleAppDescriptor.toExampleAppDescriptor(payload);
     }
+
     const authorizations = {
-      ...(await this.requireGitAuthorizations()),
+      ...(payload.gitRepository ? await this.requireGitAuthorizations() : {}),
       ...(await this.requireOpenShiftAuthorizations())
     };
     const requestConfig = await this.getRequestConfig({ clusterId: payload.clusterId, authorizations });


### PR DESCRIPTION
Git Auth is required for import flow but there's no way to do it. Probably the fix is to ensure Git Auth is not required, because it's not used