### PR TITLE
fix: now catches the 404 and returns the proper result

### DIFF
--- a/packages/launcher-client/src/client/impl/default.launcher.client.ts
+++ b/packages/launcher-client/src/client/impl/default.launcher.client.ts
@@ -182,10 +182,18 @@ export default class DefaultLauncherClient implements LauncherClient {
   public async ocExistsProject(projectName: string): Promise<ExistsResult> {
     const authorizations = await this.requireOpenShiftAuthorizations();
     const requestConfig = await this.getRequestConfig({ authorizations });
-    return await this.httpService.head<ExistsResult>(this.config.launcherURL,
-      `/services/openshift/projects/${projectName}`,
-      requestConfig
-    );
+    try {
+      return await this.httpService.head<ExistsResult>(this.config.launcherURL,
+        `/services/openshift/projects/${projectName}`,
+        requestConfig
+      );
+    } catch (e) {
+      if (e.response && e.response.status === 404) {
+        return Promise.resolve({ exists: false } as ExistsResult);
+      } else {
+        throw e;
+      }
+    }
   }
 
   private async requireGitAuthorizations() {

--- a/packages/launcher-component/src/core/project-name-input/project-name-input.tsx
+++ b/packages/launcher-component/src/core/project-name-input/project-name-input.tsx
@@ -12,12 +12,16 @@ interface ProjectNameInputProps {
 export function ProjectNameInput(props: ProjectNameInputProps) {
   const client = useLauncherClient();
   const [warning, setWarning] = useState();
+
+  const isValid = (value: string) => NAME_REGEX.test(value);
   const validateProjectName = async (projectName: string) => {
-    const result = await client.ocExistsProject(projectName);
-    if (result.exists) {
-      setWarning('Warning this project exists! Make sure you have write access.');
-    } else {
-      setWarning(undefined);
+    if (isValid(projectName)) {
+      const result = await client.ocExistsProject(projectName);
+      if (result.exists) {
+        setWarning('Warning this project exists! Make sure you have write access.');
+      } else {
+        setWarning(undefined);
+      }
     }
   }
   return (
@@ -29,7 +33,7 @@ export function ProjectNameInput(props: ProjectNameInputProps) {
       aria-label="Application Project name"
       title="Application name"
       value={props.value || ''}
-      isValid={NAME_REGEX.test(props.value || '')}
+      isValid={isValid(props.value || '')}
       onBlur={() => validateProjectName(props.value || '')}
       warning={warning}
       {...props}


### PR DESCRIPTION
fixing: #1294 

@gastaldi though while testing against preprod I get 400 responses
```
curl 'https://forge.api.prod-preview.openshift.io/api/services/openshift/projects/roomy-turn' --head 
```