### PR TITLE
fix: added support for gitea oath2

### DIFF
--- a/packages/launcher-app/.env.openshift
+++ b/packages/launcher-app/.env.openshift
@@ -2,9 +2,19 @@ REACT_APP_CREATOR_API_URL=/launch/creator
 REACT_APP_LAUNCHER_API_URL=/launch/api
 
 REACT_APP_AUTHENTICATION=oauth-openshift
+# github or gitea
+REACT_APP_GIT_PROVIDER=github
+
 REACT_APP_OAUTH_OPENSHIFT_CLIENT_ID=
 REACT_APP_OAUTH_OPENSHIFT_URL=
 
 REACT_APP_OAUTH_GITHUB_CLIENT_ID=
 REACT_APP_OAUTH_GITHUB_SECRET=
 REACT_APP_OAUTH_GITHUB_VALIDATE_URI=https://cors-anywhere.herokuapp.com/https://github.com/login/oauth/access_token
+
+REACT_APP_OAUTH_GITEA_CLIENT_ID=
+REACT_APP_OAUTH_GITEA_SECRET=
+REACT_APP_OAUTH_GITEA_URL=http://[YOUR-GITEA-URL]/login/oauth/authorize
+# fixed redirect url as gitea doesn't support wildcards
+REACT_APP_OAUTH_GITEA_REDIRECT_URL=
+REACT_APP_OAUTH_GITEA_VALIDATE_URI=http://[YOUR-GITEA-URL]/login/oauth/access_token

--- a/packages/launcher-app/src/app/config.ts
+++ b/packages/launcher-app/src/app/config.ts
@@ -58,8 +58,8 @@ function getAuthConfig(authMode: string): KeycloakConfig | OpenshiftConfig | und
         base.gitea = {
           clientId: requireEnv(process.env.REACT_APP_OAUTH_GITEA_CLIENT_ID, 'giteaOAuthClientId'),
           secret: requireEnv(process.env.REACT_APP_OAUTH_GITEA_SECRET, 'giteaOAuthSecret'),
-          url: requireEnv(process.env.REACT_APP_OAUTH_GITEA_URL, 'geteaOAuthUrl'),
-          redirectUri: requireEnv(process.env.REACT_APP_OAUTH_GITEA_REDIRECT_URL, 'geteaOAuthRedirectUrl'),
+          url: requireEnv(process.env.REACT_APP_OAUTH_GITEA_URL, 'giteaOAuthUrl'),
+          redirectUri: requireEnv(process.env.REACT_APP_OAUTH_GITEA_REDIRECT_URL, 'giteaOAuthRedirectUrl'),
           validateTokenUri: requireEnv(process.env.REACT_APP_OAUTH_GITEA_VALIDATE_URI, 'giteaOAuthValidateUri'),
         };
       }

--- a/packages/launcher-app/src/app/config.ts
+++ b/packages/launcher-app/src/app/config.ts
@@ -39,18 +39,31 @@ function getAuthConfig(authMode: string): KeycloakConfig | OpenshiftConfig | und
         url: requireEnv(process.env.REACT_APP_KEYCLOAK_URL, 'keycloakUrl'),
       } as KeycloakConfig;
     case 'oauth-openshift':
-      return {
+      const base: OpenshiftConfig = {
         openshift: {
           clientId: requireEnv(process.env.REACT_APP_OAUTH_OPENSHIFT_CLIENT_ID, 'openshiftOAuthClientId'),
           url: requireEnv(process.env.REACT_APP_OAUTH_OPENSHIFT_URL, 'openshiftOAuthUrl'),
           validateTokenUri: `${requireEnv(process.env.REACT_APP_LAUNCHER_API_URL, 'launcherApiUrl')}/services/openshift/user`,
         },
-        github: {
+        gitProvider: requireEnv(process.env.REACT_APP_GIT_PROVIDER, 'gitProvider') === 'github' ? 'github' : 'gitea',
+      };
+      if (base.gitProvider === 'github') {
+        base.github = {
           clientId: requireEnv(process.env.REACT_APP_OAUTH_GITHUB_CLIENT_ID, 'githubOAuthClientId'),
           secret: requireEnv(process.env.REACT_APP_OAUTH_GITHUB_SECRET, 'githubOAuthSecret'),
           validateTokenUri: getEnv(process.env.REACT_APP_OAUTH_GITHUB_VALIDATE_URI, 'githubOAuthValidateUri') || '/launch/github/access_token',
-        }
-      } as OpenshiftConfig;
+        };
+      }
+      if (base.gitProvider === 'gitea') {
+        base.gitea = {
+          clientId: requireEnv(process.env.REACT_APP_OAUTH_GITEA_CLIENT_ID, 'giteaOAuthClientId'),
+          secret: requireEnv(process.env.REACT_APP_OAUTH_GITEA_SECRET, 'giteaOAuthSecret'),
+          url: requireEnv(process.env.REACT_APP_OAUTH_GITEA_URL, 'geteaOAuthUrl'),
+          redirectUri: requireEnv(process.env.REACT_APP_OAUTH_GITEA_REDIRECT_URL, 'geteaOAuthRedirectUrl'),
+          validateTokenUri: requireEnv(process.env.REACT_APP_OAUTH_GITEA_VALIDATE_URI, 'giteaOAuthValidateUri'),
+        };
+      }
+      return base;
     case 'mock':
     case 'no':
       return undefined;

--- a/packages/launcher-app/src/auth/types.ts
+++ b/packages/launcher-app/src/auth/types.ts
@@ -5,7 +5,15 @@ export interface KeycloakConfig {
 }
 
 export interface OpenshiftConfig {
-  github: {
+  gitProvider: 'gitea' | 'github';
+  gitea?: {
+    clientId: string;
+    secret: string;
+    url: string;
+    redirectUri: string;
+    validateTokenUri: string;
+  };
+  github?: {
     clientId: string;
     secret: string;
     validateTokenUri: string;

--- a/packages/launcher-component/src/hubs/dest-repository-hub.tsx
+++ b/packages/launcher-component/src/hubs/dest-repository-hub.tsx
@@ -26,8 +26,8 @@ export const DestRepositoryHub: FormHub<DestRepositoryFormValue> = {
       return (
         <OverviewEmpty
           id={`${DestRepositoryHub.id}-unauthorized`}
-          title="You need to authorize GitHub."
-          action={<ButtonLink href={auth.generateAuthorizationLink('github')}>Authorize</ButtonLink>}
+          title="You need to authorize Git."
+          action={<ButtonLink href={auth.generateAuthorizationLink()}>Authorize</ButtonLink>}
         >
           Once authorized, you will be able to choose a repository provider and a location...
         </OverviewEmpty>
@@ -47,7 +47,7 @@ export const DestRepositoryHub: FormHub<DestRepositoryFormValue> = {
     return (
       <OverviewComplete id={DestRepositoryHub.id} title={`Destination Repository is configured`}>
         <SpecialValue>{valueToPath(props.value.userRepositoryPickerValue!)}</SpecialValue> is configured
-        as destination repository on GitHub.
+        as destination repository on Git.
       </OverviewComplete>
     );
   },
@@ -64,8 +64,7 @@ export const DestRepositoryHub: FormHub<DestRepositoryFormValue> = {
           (inputProps) => (
             <React.Fragment>
               <DescriptiveHeader
-                description="You can select where your application source code will be located,
-               for now the only available provider is GitHub."
+                description="You can select where your application source code will be located."
               />
               <GitInfoLoader>
                 {(gitInfo) => (


### PR DESCRIPTION
fixing: #1298

For testing install gitea locally and configure oauth2 [like described](https://docs.gitea.io/en-us/oauth2-provider/)

As gitea doesn't support wildcard redirects I've added a redirect property in the config.