### PR TITLE
feat: introduce analytics context

### DIFF
--- a/packages/launcher-component/src/analytics/analytics-context.ts
+++ b/packages/launcher-component/src/analytics/analytics-context.ts
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react';
+import { Analytics } from './analytics';
+
+class LoggingAnalytics implements Analytics {
+    init() {
+       console.log("analytics>init")
+    }    
+    
+    pageview(path: string) {
+        console.log(`analytics>pageview(${path})`)
+    }
+
+    event(name: string, action: string, label?: string, value?: number, params?: object) {
+        console.log(`analytics>event(${name}, ${action}, ${label}, ${value})`)
+    }
+}
+export const AnalyticsContext = React.createContext<Analytics>(new LoggingAnalytics());
+
+export function useAnalytics(): Analytics {
+  return useContext(AnalyticsContext);
+}

--- a/packages/launcher-component/src/analytics/analytics.ts
+++ b/packages/launcher-component/src/analytics/analytics.ts
@@ -1,0 +1,5 @@
+export interface Analytics {
+    init();
+    pageview(path: string);
+    event(name: string, action: string, label?: string, value?: number, params?: object);
+}

--- a/packages/launcher-component/src/analytics/index.ts
+++ b/packages/launcher-component/src/analytics/index.ts
@@ -1,0 +1,2 @@
+export * from './analytics';
+export * from './analytics-context';

--- a/packages/launcher-component/src/core/text-input/text-input.tsx
+++ b/packages/launcher-component/src/core/text-input/text-input.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TextInput, FormGroup, TextInputProps, FormGroupProps, Omit } from '@patternfly/react-core';
+import { useAnalytics } from '../../analytics';
 
 interface LaunchTextInputProps extends Omit<TextInputProps & FormGroupProps, 'fieldId' | 'id'> {
   id: string;
@@ -8,6 +9,7 @@ interface LaunchTextInputProps extends Omit<TextInputProps & FormGroupProps, 'fi
 export function LaunchTextInput(props: LaunchTextInputProps) {
   const [isDirty, setIsDirty] = useState(false);
   const { onChange, isValid, helperTextInvalid, label, ...rest } = props;
+  const analytics = useAnalytics();
   return (
     <FormGroup
       fieldId={props.id}
@@ -17,6 +19,9 @@ export function LaunchTextInput(props: LaunchTextInputProps) {
     >
       <TextInput
         onChange={(value, event) => {
+          if(!isDirty) {
+            analytics.event('Input', 'Customized-Value', props.id);
+          }
           setIsDirty(true);
           if (onChange) {
             onChange(value, event);

--- a/packages/launcher-component/src/flows/create-new-app-flow.tsx
+++ b/packages/launcher-component/src/flows/create-new-app-flow.tsx
@@ -186,6 +186,7 @@ export function CreateNewAppFlow(props: { appName?: string; onCancel?: () => voi
 
   return (
     <LaunchFlow
+      id="create-new-app"
       title={(
         <ProjectNameInput
           prefix="Create New Application as:"

--- a/packages/launcher-component/src/flows/deploy-example-app-flow.tsx
+++ b/packages/launcher-component/src/flows/deploy-example-app-flow.tsx
@@ -146,6 +146,7 @@ export function DeployExampleAppFlow(props: { appName?: string; onCancel?: () =>
 
   return (
     <LaunchFlow
+      id="deploy-example-app"
       title={(
         <ProjectNameInput
           prefix="Create Example Application as:"

--- a/packages/launcher-component/src/flows/import-existing-flow.tsx
+++ b/packages/launcher-component/src/flows/import-existing-flow.tsx
@@ -104,6 +104,7 @@ export function ImportExistingFlow(props: { appName?: string; onCancel?: () => v
 
   return (
     <LaunchFlow
+      id="import-existing-flow"
       title={(
         <ProjectNameInput
           prefix="Import an Existing Application as:"

--- a/packages/launcher-component/src/flows/launch-flow.tsx
+++ b/packages/launcher-component/src/flows/launch-flow.tsx
@@ -12,6 +12,7 @@ import { effectSafety } from '../core/stuff';
 import { ProcessingApp } from '../next-steps/processing-app';
 import { DownloadNextSteps } from '../next-steps/download-next-steps';
 import { LaunchNextSteps } from '../next-steps/launch-next-steps';
+import { useAnalytics } from '../analytics/analytics-context';
 
 enum Status {
   EDITION = 'EDITION', RUNNING = 'RUNNING', COMPLETED = 'COMPLETED', ERROR = 'ERROR', DOWNLOADED = 'DOWNLOADED'
@@ -95,6 +96,7 @@ interface RunState {
 }
 
 interface LaunchFlowProps {
+  id: string;
   title: string | ReactNode;
   items: any[];
   hint?: string;
@@ -109,6 +111,10 @@ interface LaunchFlowProps {
 export function LaunchFlow(props: LaunchFlowProps) {
   const [run, setRun] = useState<RunState>({status: Status.EDITION, statusMessages: []});
   const client = useLauncherClient();
+  const analytics = useAnalytics();
+  
+  useEffect(() => analytics.event('Flow', 'Open', props.id), []);
+
   const canDownload = props.canDownload === undefined || props.canDownload;
   const onCancel = props.onCancel || (() => {
   });

--- a/packages/launcher-component/src/index.ts
+++ b/packages/launcher-component/src/index.ts
@@ -4,6 +4,7 @@ export * from './flows/import-existing-flow';
 export * from './flows/deploy-example-app-flow';
 export * from './contexts/launcher-client-provider';
 export * from './contexts/launcher-client-context';
+export * from './analytics';
 export * from './loaders/new-app-runtimes-loaders';
 export * from './loaders/enum-loader';
 export * from './core/data-loader/data-loader';

--- a/packages/launcher-component/src/pickers/dependencies-picker.tsx
+++ b/packages/launcher-component/src/pickers/dependencies-picker.tsx
@@ -3,6 +3,7 @@ import { PlusIcon, TimesIcon } from "@patternfly/react-icons";
 import React, { Fragment, useState } from "react";
 import { InputProps, Picker } from "../core/types";
 import style from './dependencies.module.scss';
+import { useAnalytics } from '../analytics';
 
 export interface DependencyItem {
   id: string;
@@ -60,6 +61,7 @@ export const DependenciesPicker: Picker<DependenciesPickerProps, DependenciesPic
   checkCompletion: (value: DependenciesPickerValue) => !!value.dependencies && value.dependencies.length > 0,
   Element: (props: DependenciesPickerProps) => {
     const [filter, setFilter] = useState('');
+    const analytics = useAnalytics();
     const dependencies = props.value.dependencies || [];
     const dependenciesSet = new Set(dependencies);
     const dependencyItemById = new Map(props.items.map(item => [item.id, item]));
@@ -67,11 +69,13 @@ export const DependenciesPicker: Picker<DependenciesPickerProps, DependenciesPic
     const addDep = (id: string) => {
       dependenciesSet.add(id);
       props.onChange({ dependencies: Array.from(dependenciesSet) });
+      analytics.event('Picker', 'Add-Dependency', id);
     };
 
     const removeDep = (id: string) => {
       dependenciesSet.delete(id);
       props.onChange({ dependencies: Array.from(dependenciesSet) });
+      analytics.event('Picker', 'Remove-Dependency', id)
     };
 
     const filterFunction = (d: DependencyItem) =>


### PR DESCRIPTION
- Add base/generic `Analytics` interface
- Add `AnalyticsContext` and `useAnalytics` (default analytics is just logging)
- use analytics in flows, in dependency picker and in text input
- implementation is in charge of implementing and defining the Analytics implementation (and calling init)
